### PR TITLE
Enable shared notifications and native Gambit plugins

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1060,11 +1060,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1783385478,
-        "narHash": "sha256-S2/54WrCiMOVy0CRfWzVc8CIcj3PfD9CMqlJCy8aP3g=",
+        "lastModified": 1783901562,
+        "narHash": "sha256-QpHV5pslzVukGhODiREI30kZXM7GVmR/d1DKXL8G/aE=",
         "owner": "joshsymonds",
         "repo": "gambit",
-        "rev": "b83e44899e97d11f010b8c02fe1a16b5f6365c5a",
+        "rev": "6113aad6a6e1bb55cb8d6cc74967f5b706434c10",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -195,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783624793,
-        "narHash": "sha256-3+6xJBSF3o27OIF1DMLzl1aZH71nU+OXKk2I2dZ5DAk=",
+        "lastModified": 1783899715,
+        "narHash": "sha256-C3buAmlL8/Ci16SlEuF+SMOow1hvtXw8tNswaqVuinI=",
         "owner": "joshsymonds",
         "repo": "cc-tools",
-        "rev": "3125407bb193d8d35591544e696df1f3998c606a",
+        "rev": "47f9277fa2ed31b4f050e45479647156324618f6",
         "type": "github"
       },
       "original": {

--- a/home-manager/claude-code/default.nix
+++ b/home-manager/claude-code/default.nix
@@ -525,8 +525,9 @@ in {
       CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
       CLAUDE_CODE_NO_FLICKER = "1";
       CLAUDE_CODE_TMUX_TRUECOLOR = "1";
-      CLAUDE_HOOKS_NTFY_URL_FILE = config.age.secrets."ntfy-url".path;
-      CLAUDE_HOOKS_NTFY_TOKEN_FILE = config.age.secrets."ntfy-token".path;
+      # Shared by Claude's stdin hooks and Codex's argv notify command.
+      CC_TOOLS_NTFY_URL_FILE = config.age.secrets."ntfy-url".path;
+      CC_TOOLS_NTFY_TOKEN_FILE = config.age.secrets."ntfy-token".path;
       # The only reliable way to disable auto-updates for native installs.
       # settings.json autoUpdater.disabled is cosmetic; ~/.claude.json autoUpdates
       # is bypassed by autoUpdatesProtectedForNative for native installMethod.
@@ -1006,10 +1007,10 @@ in {
       # does. Same reason ntfy-notify reads its secret in-shell. The daemon
       # fail-fasts if the URL is empty, so a missing secret surfaces loudly.
       ExecStart = pkgs.writeShellScript "cc-tools-notifyd-start" ''
-        export CLAUDE_HOOKS_NTFY_URL
-        CLAUDE_HOOKS_NTFY_URL="$(cat "${config.age.secrets."ntfy-url".path}")"
-        export CLAUDE_HOOKS_NTFY_TOKEN
-        CLAUDE_HOOKS_NTFY_TOKEN="$(cat "${config.age.secrets."ntfy-token".path}")"
+        export CC_TOOLS_NTFY_URL
+        CC_TOOLS_NTFY_URL="$(cat "${config.age.secrets."ntfy-url".path}")"
+        export CC_TOOLS_NTFY_TOKEN
+        CC_TOOLS_NTFY_TOKEN="$(cat "${config.age.secrets."ntfy-token".path}")"
         exec ${cc-tools}/bin/cc-tools notifyd
       '';
       Restart = "on-failure";

--- a/home-manager/claude-code/hooks/README.md
+++ b/home-manager/claude-code/hooks/README.md
@@ -1,4 +1,4 @@
-# Claude Code Hooks
+# Coding-agent hooks
 
 Hook scripts deployed verbatim to `~/.claude/hooks/` and `~/.claude-work/hooks/`
 by `../default.nix` (`mkClaudeFiles`), wired up in `../settings.json`:
@@ -8,15 +8,17 @@ by `../default.nix` (`mkClaudeFiles`), wired up in `../settings.json`:
 ## Notifications live in cc-tools
 
 The ntfy sender is `cc-tools notify` (https://github.com/joshsymonds/cc-tools,
-`internal/notify/`), wired in `../settings.json` on the `Stop`, `Notification`
-(matcher `permission_prompt|idle_prompt|agent_needs_input|agent_completed`),
-and `SessionEnd` events. It reads the same `CLAUDE_HOOKS_NTFY_URL_FILE` /
-`CLAUDE_HOOKS_NTFY_TOKEN_FILE` agenix env wiring as the old bash hook did,
-and keeps the tag contract gnomon's subscriber (`home-manager/ntfy-notify/`)
-chimes on: blocked = priority 5 + `question`, done/info = 4/3 +
-`white_check_mark`.
+`internal/notify/`). Claude wires it in `../settings.json` on the `Stop`,
+`Notification` (matcher
+`permission_prompt|idle_prompt|agent_needs_input|agent_completed`), and
+`SessionEnd` events. Codex wires the same binary through the top-level `notify`
+key in `home-manager/codex/default.nix`; its `agent-turn-complete` JSON arrives
+as one argv value instead of stdin. Both read the
+`CC_TOOLS_NTFY_URL_FILE` / `CC_TOOLS_NTFY_TOKEN_FILE` agenix environment and
+keep the tag contract gnomon's subscriber (`home-manager/ntfy-notify/`) chimes
+on: blocked = priority 5 + `question`, done/info = 4/3 + `white_check_mark`.
 
-What it adds over the deleted `ntfy-notifier.sh`: transcript-derived gates
+For Claude, it adds transcript-derived gates over the deleted `ntfy-notifier.sh`
 (silent while a `/goal` is unmet or background tasks are pending; silent in
 subagent contexts), a Haiku judge that writes the notification title/body
 (`<project> · <task>` instead of window-title guessing), a per-session

--- a/home-manager/codex/default.nix
+++ b/home-manager/codex/default.nix
@@ -1,4 +1,10 @@
-{inputs, ...}: {
+{
+  inputs,
+  pkgs,
+  ...
+}: let
+  cc-tools = inputs.cc-tools.packages.${pkgs.stdenv.hostPlatform.system}.default;
+in {
   # Declarative Codex CLI config. The /statusline interactive picker won't
   # be able to save changes (config.toml is a Nix-store symlink); edit this
   # file and rebuild instead.
@@ -9,6 +15,11 @@
   home.file.".codex/config.toml".text = ''
     model = "gpt-5.6-sol"
     model_reasoning_effort = "xhigh"
+
+    # Codex passes agent-turn-complete JSON as one argv value. cc-tools
+    # normalizes that into the same ntfy delivery path Claude's stdin hooks
+    # use, without invoking the Claude transcript/judge pipeline.
+    notify = ["${cc-tools}/bin/cc-tools", "notify"]
 
     # Equivalent to --dangerously-bypass-approvals-and-sandbox. This machine
     # is intentionally configured to let Codex work outside the repo without
@@ -23,6 +34,12 @@
     trust_level = "trusted"
 
     [tui]
+    # External notify owns turn-complete delivery. Keep Codex's built-in
+    # terminal notification only for approvals, which external notify does
+    # not currently emit.
+    notifications = ["approval-requested"]
+    notification_condition = "unfocused"
+    notification_method = "auto"
     status_line = [
       "model-with-reasoning",
       "current-dir",
@@ -37,6 +54,5 @@
   # Keep the submission helper pinned with the rest of the Codex install.
   # It lives in the OpenAI Developers plugin upstream, but does not require
   # installing that plugin's Platform connector or its unrelated skills.
-  home.file.".codex/skills/chatgpt-app-submission".source =
-    "${inputs.openai-plugins}/plugins/openai-developers/skills/chatgpt-app-submission";
+  home.file.".codex/skills/chatgpt-app-submission".source = "${inputs.openai-plugins}/plugins/openai-developers/skills/chatgpt-app-submission";
 }

--- a/home-manager/codex/default.nix
+++ b/home-manager/codex/default.nix
@@ -1,9 +1,20 @@
 {
   inputs,
+  lib,
   pkgs,
   ...
 }: let
   cc-tools = inputs.cc-tools.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  gambitPackages = inputs.gambit.packages.${pkgs.stdenv.hostPlatform.system};
+  gambitHasCodex = gambitPackages ? codex && inputs.gambit ? lib && inputs.gambit.lib ? version;
+  gambitCodex =
+    if gambitHasCodex
+    then gambitPackages.codex
+    else null;
+  gambitVersion =
+    if gambitHasCodex
+    then inputs.gambit.lib.version
+    else "unavailable";
 in {
   # Declarative Codex CLI config. The /statusline interactive picker won't
   # be able to save changes (config.toml is a Nix-store symlink); edit this
@@ -26,6 +37,13 @@ in {
     # interrupting for per-command or per-directory confirmation.
     approval_policy = "never"
     sandbox_mode = "danger-full-access"
+
+    ${lib.optionalString gambitHasCodex ''
+        # Home Manager also materializes the matching cache entry below, so
+        # Gambit is installed and enabled without mutable `codex plugin add` state.
+      [plugins."gambit@personal"]
+      enabled = true
+    ''}
 
     # Trust is normally persisted by codex rewriting config.toml, which
     # fails against this read-only store symlink — declare trusted
@@ -55,4 +73,38 @@ in {
   # It lives in the OpenAI Developers plugin upstream, but does not require
   # installing that plugin's Platform connector or its unrelated skills.
   home.file.".codex/skills/chatgpt-app-submission".source = "${inputs.openai-plugins}/plugins/openai-developers/skills/chatgpt-app-submission";
+
+  # Gambit's Codex-native bundle is exposed through the implicit personal
+  # marketplace. The marketplace path is rooted at $HOME, so
+  # ./plugins/gambit resolves to the Nix-managed ~/plugins/gambit symlink.
+  # The recursive cache entry plus the enabled config block avoid mutable
+  # `codex plugin add` state; INSTALLED_BY_DEFAULT records the same policy in
+  # the marketplace UI.
+  home.file."plugins/gambit" = lib.mkIf gambitHasCodex {source = gambitCodex;};
+  home.file.".codex/plugins/cache/personal/gambit/${gambitVersion}" = lib.mkIf gambitHasCodex {
+    source = gambitCodex;
+    # Codex intentionally ignores a cache version that is itself a symlink.
+    # Build a real directory whose contents link into the immutable bundle.
+    recursive = true;
+  };
+  home.file.".agents/plugins/marketplace.json" = lib.mkIf gambitHasCodex {
+    text = builtins.toJSON {
+      name = "personal";
+      interface.displayName = "Personal";
+      plugins = [
+        {
+          name = "gambit";
+          source = {
+            source = "local";
+            path = "./plugins/gambit";
+          };
+          policy = {
+            installation = "INSTALLED_BY_DEFAULT";
+            authentication = "ON_INSTALL";
+          };
+          category = "Coding";
+        }
+      ];
+    };
+  };
 }

--- a/home-manager/ntfy-notify/default.nix
+++ b/home-manager/ntfy-notify/default.nix
@@ -1,12 +1,12 @@
-# gnomon-only: subscribe to the Claude ntfy topic and surface every
+# gnomon-only: subscribe to the coding-agent ntfy topic and surface every
 # message as a DankMaterialShell desktop popup + a synthesized chime.
 #
 # This is the gnomon end of the "ntfy is the one true notification path"
 # design. Claude's own terminal notification is disabled everywhere
 # (settings.json preferredNotifChannel=notifications_disabled); the
-# Stop/Notification/SessionEnd hooks (`cc-tools notify`, wired in
-# home-manager/claude-code/settings.json) POST to the ntfy topic with a
-# classifying tag. Every agent — gnomon's
+# Claude Stop/Notification/SessionEnd hooks and Codex's external
+# agent-turn-complete notifier POST to the ntfy topic with a classifying tag.
+# Every agent — gnomon's
 # own AND vermissian's — therefore comes back through this one
 # subscriber, so the desktop popup and the watch push are the same
 # signal from the same source. gnomon's own agents loop back through
@@ -42,9 +42,9 @@
     # freedesktop hint as of the josh/notif-suppress-sound patch on the
     # dank-material-shell integration branch — without that patch DMS
     # double-sounds nondeterministically (dedup-dependent).
-    ${pkgs.libnotify}/bin/notify-send -a Claude -u "$urgency" \
+    ${pkgs.libnotify}/bin/notify-send -a "Coding Agent" -u "$urgency" \
       -h boolean:suppress-sound:true -- \
-      "''${title:-Claude}" "''${message:-}"
+      "''${title:-Coding Agent}" "''${message:-}"
     exec ${pkgs.pipewire}/bin/pw-play "${sounds}/$sound.wav"
   '';
 
@@ -68,7 +68,7 @@
 in {
   systemd.user.services.ntfy-notify = {
     Unit = {
-      Description = "Surface Claude ntfy notifications as desktop popups + chime";
+      Description = "Surface coding-agent ntfy notifications as desktop popups + chime";
       After = ["graphical-session.target"];
       PartOf = ["graphical-session.target"];
     };


### PR DESCRIPTION
## What changed

- pin `cc-tools` to the published Codex-notification commit
- configure Codex external `notify` to use the Nix-store `cc-tools` binary
- reserve Codex built-in TUI notifications for approval requests
- migrate Claude hooks, Codex, and notifyd to shared `CC_TOOLS_NTFY_*` agenix variables
- make the desktop subscriber agent-neutral
- pin Gambit to its native Codex-plugin revision
- install and enable `gambit@personal` declaratively through Home Manager
- materialize Codex's personal marketplace and immutable plugin cache in the layout Codex expects

## Why

Claude and Codex now share one ntfy delivery implementation despite their different payload transports. The Nix configuration installs the matching binary and exposes the same secrets to both agent processes.

Gambit's common source now builds backend-native Claude and Codex bundles. Vermissian installs both through Nix, while Codex discovers the personal plugin as already installed and enabled without mutable `codex plugin add` state.

## Validation

- Gambit `just check`: 9 tests passed
- Gambit `nix flake check`
- hook shellcheck and Git whitespace checks
- full Vermissian system closure build
- `update` switched Vermissian successfully
- `codex plugin list --available --json` reports `gambit@personal` 1.17.0 installed and enabled
- live hand-crafted Claude stdin and Codex argv payloads both delivered through ntfy
- installed `codex exec` emitted a `TurnComplete` notification through configured `notify`
- installed `claude -p` emitted a composed `Stop` notification through configured hooks
