### PR TITLE
Add escalation-final executor seat and Codex agent role

### DIFF
--- a/home-manager/claude-code/codex-executor-config.nix
+++ b/home-manager/claude-code/codex-executor-config.nix
@@ -50,6 +50,11 @@ in {
         reasoning_effort = "high";
         sandbox = "danger-full-access";
       };
+    escalation-final =
+      solXhigh
+      // {
+        sandbox = "danger-full-access";
+      };
     finder =
       solXhigh
       // {

--- a/home-manager/codex/agent-roles.nix
+++ b/home-manager/codex/agent-roles.nix
@@ -5,6 +5,12 @@
     model = "gpt-5.6-sol";
     reasoningEffort = "high";
   };
+  escalation-final = {
+    description = "Terminal escalation for a task that survived the fresh escalation attempt; repeats with updated evidence until the task verifies clean.";
+    instructions = "Follow the task and any referenced contract exactly. Use the maximum reasoning budget to resolve the reported defect without broadening scope.";
+    model = "gpt-5.6-sol";
+    reasoningEffort = "xhigh";
+  };
   explorer = {
     description = "Answer a specific read-only codebase question quickly with file and line evidence.";
     instructions = "Investigate read-only. Do not edit files. Answer only the requested question with checkable file:line evidence and report NOT FOUND when appropriate.";


### PR DESCRIPTION
Adds the `escalation-final` seat (Sol xhigh, `danger-full-access`) to the gambit executor registry generated into `~/.claude/gambit/executors.json`, and the matching `escalation-final` role in the Codex agent roles. This is the terminal rung of gambit's revised repair ladder — repeated maximum-reasoning escalation until the task verifies clean, replacing the human handoff rung.

Both files pass `nix-instantiate --parse`. Companion PR: joshsymonds/gambit#1 (schema, ladder mechanics, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)