### PR TITLE
fix(ultraviolet): recover SABnzbd when the NAS misses the boot automount

### DIFF
--- a/hosts/ultraviolet/services/arr-healthcheck.nix
+++ b/hosts/ultraviolet/services/arr-healthcheck.nix
@@ -122,6 +122,46 @@
       fi
     }
 
+    # Check SABnzbd (podman container sharing Gluetun's network namespace).
+    #
+    # Unlike every other check here, "not running" is a fault rather than a
+    # reason to skip. podman-sabnzbd carries Requires=mnt-video.mount, so a
+    # boot where the NAS misses the 10s automount timeout cancels the start
+    # job with result 'dependency' — and systemd never retries a cancelled
+    # start job. SABnzbd then stays dead indefinitely while every *arr still
+    # reports healthy, because each only probes its own API. Starting the
+    # unit here re-triggers the automount, so SABnzbd comes back on the first
+    # pass after the NAS answers.
+    check_sabnzbd() {
+      if ! ${pkgs.systemd}/bin/systemctl is-active --quiet podman-sabnzbd; then
+        echo "sabnzbd: not running, starting"
+        if ${pkgs.systemd}/bin/systemctl start podman-sabnzbd 2>/dev/null; then
+          echo "sabnzbd: started"
+        else
+          echo "sabnzbd: start failed (NAS share likely still unreachable)"
+        fi
+        return
+      fi
+
+      # SABnzbd can stall its web interface while unpacking, and a gluetun
+      # restart leaves it alive with a dead network namespace. Retry before
+      # declaring it wedged so a busy-but-fine instance is never bounced
+      # mid-download.
+      local http_code=""
+      for _ in 1 2 3; do
+        http_code=$(${pkgs.curl}/bin/curl -s -m 10 -o /dev/null -w "%{http_code}" \
+          "http://localhost:8080/api?mode=version" 2>/dev/null)
+        if [[ "$http_code" == "200" ]]; then
+          echo "sabnzbd: healthy"
+          return
+        fi
+        sleep 5
+      done
+
+      echo "sabnzbd: unhealthy (HTTP $http_code)"
+      graceful_restart "podman-sabnzbd"
+    }
+
     # Run all checks
     ${builtins.concatStringsSep "\n" (map (svc: ''
         check_arr "${svc.name}" "${toString svc.port}" "${svc.configXml}" "${svc.apiVersion}"
@@ -129,10 +169,11 @@
       arrServices)}
     check_jellyfin
     check_jellyseerr
+    check_sabnzbd
   '';
 in {
   systemd.services.media-healthcheck = {
-    description = "Health check for media services (Sonarr, Radarr, Readarr, Prowlarr, Jellyfin, Jellyseerr)";
+    description = "Health check for media services (Sonarr, Radarr, Readarr, Prowlarr, Jellyfin, Jellyseerr, SABnzbd)";
     serviceConfig = {
       Type = "oneshot";
       ExecStart = healthCheckScript;


### PR DESCRIPTION
## What broke

The 2026-07-23 17:06 boot raced the NAS:

```
17:06:55 mnt-video.automount: Got automount request for /mnt/video, triggered by 2425 (.podman-wrapped)
17:07:02 mnt-video.mount: Mounting timed out. Terminating.
17:07:02 mnt-video.mount: Failed with result 'timeout'.
17:07:02 Dependency failed for podman-sabnzbd.service.
```

`podman-sabnzbd` carries `Requires=mnt-video.mount` via the `RequiresMountsFor` added to keep the container from binding the bare local directory and filling the root disk. When the NAS misses the deliberate 10s `x-systemd.mount-timeout`, the start job is cancelled with result `dependency` — and systemd never retries a cancelled start job.

SABnzbd stayed down for ~26 hours. Gluetun owns the published port, so `:8080` kept accepting TCP and returning connection-refused from inside the netns. Radarr and Sonarr went on grabbing releases and handing them to a dead client; every item stalled as `downloadClientUnavailable`.

## Why nothing caught it

- `media-healthcheck` only probed the *arr APIs. All four stayed healthy the whole time — each service only checks itself, and none of them fail their own health probe because a *download client* is unreachable.
- `sabnzbd-vpn-health` correctly failed every 30 minutes for a full day (`❌ Unable to query Mullvad status from SABnzbd container`) but only exits non-zero; nothing acts on it.

The *arrs would have recovered on their own — their download-client backoff caps at 6h and retries — but SABnzbd was never coming back without a manual start.

## The fix

Add `check_sabnzbd` to `media-healthcheck` (5-minute timer).

Unlike every other check in that script, **"not running" is a fault, not a reason to skip**. Starting the unit re-triggers the automount, so SABnzbd returns on the first pass after the NAS answers. Worst case exposure drops from unbounded to ~5 minutes.

A wedged-but-running instance (gluetun bounce leaves SABnzbd alive with a dead network namespace) is restarted only after three failed probes over ~30s, so an instance that is merely slow while unpacking is never bounced mid-download.

## Verification

- `nix flake check` — all green, treefmt included
- `nix eval` of `nixosConfigurations.ultraviolet.config.system.build.toplevel.drvPath` — full config evaluates
- Built the generated script and `bash -n` clean; confirmed `check_sabnzbd` is emitted and invoked

Not yet deployed — needs `update` on ultraviolet after merge.

## Immediate state (already restored by hand, no deploy needed)

SABnzbd is back up and on Mullvad (`us-lax-wg-403`). Restarted Radarr/Sonarr to clear the download-client backoff, dropped the two phantom queue entries, and re-ran the search. The 13th Warrior and Goodrich both downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)