### PR TITLE
cleanup-services: prune stale /tmp build caches; fix flake check on main

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -605,7 +605,6 @@
             codexConfig = import ./home-manager/codex/managed-config.nix {
               pkgs = checkPkgs;
               lib = checkPkgs.lib;
-              ccTools = "/test/cc-tools";
               gambitHasCodex = true;
             };
           };

--- a/modules/services/cleanup-services.nix
+++ b/modules/services/cleanup-services.nix
@@ -32,6 +32,18 @@ in {
       default = true;
       description = "Run 'nix-collect-garbage --delete-older-than 3d' + 'nix-store --gc' in the cleanup pass.";
     };
+
+    tmpBuildCachePrune = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Delete stale per-run build caches in /tmp (Go caches, arena-run dirs, scratch dirs) left behind by agent runs.";
+    };
+
+    tmpBuildCacheAgeDays = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 3;
+      description = "Minimum age in days before a /tmp build-cache dir is deleted.";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -62,6 +74,16 @@ in {
               ${pkgs.podman}/bin/podman system prune -a --volumes -f || true
               echo "Podman cleanup completed"
             fi
+          ''}
+
+          ${lib.optionalString cfg.tmpBuildCachePrune ''
+            echo "Pruning stale build caches in /tmp..."
+            ${pkgs.findutils}/bin/find /tmp -mindepth 1 -maxdepth 1 \
+              \( -name '*cache*' -o -name '*go-build*' -o -name 'arena-run-*' \
+                 -o -name 'tmp.*' -o -name '*-scratch' -o -name '*shared-target*' \) \
+              -mtime +${toString cfg.tmpBuildCacheAgeDays} \
+              -exec rm -rf {} + || true
+            echo "/tmp build-cache prune completed"
           ''}
 
           ${lib.optionalString cfg.nixGC ''

--- a/tests/claude-codex-executors.nix
+++ b/tests/claude-codex-executors.nix
@@ -11,7 +11,6 @@
   interactiveConfigToml = import ../home-manager/codex/managed-config.nix {
     inherit pkgs;
     lib = pkgs.lib;
-    ccTools = "/test/cc-tools";
     gambitHasCodex = true;
   };
 in


### PR DESCRIPTION
## Why

vermissian filled to 86% again. Manual cleanup today reclaimed ~300G (86% → 50%); the dominant recurring leak was ~130G of per-run agent Go build caches in /tmp (`vada-gocache.*`, `arena-run-*`, `tiltyard-*`, …) — 33k entries, nothing on NixOS ages /tmp, and the existing cleanup timer only covers Docker/Podman/Nix.

## What

- `cleanup-services.nix`: new `tmpBuildCachePrune` option (default on) added to the daily pass — deletes top-level /tmp dirs matching the build-cache patterns (`*cache*`, `*go-build*`, `arena-run-*`, `tmp.*`, `*-scratch`, `*shared-target*`) older than `tmpBuildCacheAgeDays` (default 3). Same pattern set validated in today's manual cleanup.
- Fix `nix flake check` on main: 58f9307 dropped the `ccTools` parameter from `codex/managed-config.nix` but left the argument at two call sites (`flake.nix`, `tests/claude-codex-executors.nix`), so evaluation failed.

## Verification

`nix flake check` passes (was failing on main before the ccTools fix).

Takes effect on ultraviolet and vermissian (the hosts with `services.cleanup-services.enable`) after merge + `update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)